### PR TITLE
for_preps/ltc2358

### DIFF
--- a/Documentation/devicetree/bindings/iio/adc/adi,ltc2358.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ltc2358.yaml
@@ -47,6 +47,8 @@ patternProperties:
 required:
   - compatible
 
+additionalProperties: false
+
 examples:
   - |
     ltc2358: ltc2358@0 {

--- a/Documentation/devicetree/bindings/iio/adc/adi,ltc2358.yaml
+++ b/Documentation/devicetree/bindings/iio/adc/adi,ltc2358.yaml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+# Copyright 2023 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/bindings/iio/adc/adi,ltc2358.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Linear Technology LTC2358 ADC device driver
+
+maintainers:
+  - Kim Seer Paller <kimseer.paller@analog.com>
+
+description: |
+  Bindings for the Analog Devices LTC2358 ADC device. Datasheet can be
+  found here:
+    https://www.analog.com/media/en/technical-documentation/data-sheets/235818f.pdf
+
+properties:
+  compatible:
+    enum:
+      - adi,ltc2358
+
+  reg:
+    maxItems: 1
+
+patternProperties:
+  "^channel@([0-7])$":
+    type: object
+    description: Represents one input channel
+
+    properties:
+      reg:
+        description: Represents the index of a channel
+        minimum: 0
+        maximum: 7
+
+      config-number:
+        description: The configuration number of the channel
+        items:
+          minimum: 0
+          maximum: 7
+
+    required:
+      - reg
+      - config-number
+
+required:
+  - compatible
+
+examples:
+  - |
+    ltc2358: ltc2358@0 {
+            compatible = "adi,ltc2358";
+            reg = <0>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+            spi-max-frequency = <10000000>;
+
+            channel@0 {
+                    reg = <0>;
+                    config-number = <2>;
+            };
+
+            channel@1 {
+                    reg = <1>;
+                    config-number = <3>;
+            };
+    };

--- a/drivers/iio/Kconfig.adi
+++ b/drivers/iio/Kconfig.adi
@@ -80,6 +80,7 @@ config IIO_ALL_ADI_DRIVERS
 	imply XILINX_XADC if (ARCH_ZYNQ || ARCH_ZYNQMP || MICROBLAZE)
 	imply LTC2497
 	imply LTC2308
+	imply LTC2358
 	imply LTC2387
 	imply AD8366
 	imply ADA4250

--- a/drivers/iio/adc/Kconfig
+++ b/drivers/iio/adc/Kconfig
@@ -849,6 +849,16 @@ config LTC2308
 	  This driver can also be built as a module. If so, the module will
 	  be called ltc2308.
 
+config LTC2358
+	tristate "Linear Technology LTC2358 ADC driver"
+	depends on SPI
+	help
+	  Say yes here to build support for Linear Technology LTC2358
+	  CMOS Mode, 200ksps/Ch Differential ±10.24V ADC.
+
+	  This driver can also be built as a module. If so, the module will
+	  be called ltc2358.
+
 config LTC2387
 	tristate "Linear Technology LTC2387 ADC driver"
 	depends on PWM

--- a/drivers/iio/adc/Makefile
+++ b/drivers/iio/adc/Makefile
@@ -127,6 +127,7 @@ obj-$(CONFIG_LP8788_ADC) += lp8788_adc.o
 obj-$(CONFIG_LPC18XX_ADC) += lpc18xx_adc.o
 obj-$(CONFIG_LPC32XX_ADC) += lpc32xx_adc.o
 obj-$(CONFIG_LTC2308) += ltc2308.o
+obj-$(CONFIG_LTC2358) += ltc2358.o
 obj-$(CONFIG_LTC2387) += ltc2387.o
 obj-$(CONFIG_LTC2471) += ltc2471.o
 obj-$(CONFIG_LTC2485) += ltc2485.o

--- a/drivers/iio/adc/ltc2358.c
+++ b/drivers/iio/adc/ltc2358.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+/*
+ * Analog Devices LTC2358 ADC
+ *
+ * Copyright 2023 Analog Devices Inc.
+ */
+#include <linux/device.h>
+#include <linux/err.h>
+#include <linux/iio/iio.h>
+#include <linux/init.h>
+#include <linux/iio/sysfs.h>
+#include <linux/module.h>
+#include <linux/property.h>
+#include <linux/spi/spi.h>
+#include <linux/types.h>
+
+#define LTC2358_BYTES_PER_CH	3
+#define LTC2358_CHANNEL_MSK     GENMASK(2, 0)
+#define LTC2358_NUM_CH          7
+#define LTC2358_NUM_CONFIG	7
+#define T_CONVH			40
+#define T_QUIET			20
+#define LTC2358_CREATE_CONFIG_WORD(channel, config_number, config_word)		\
+	*(config_word) |= ((uint32_t)(config_number & LTC2358_CHANNEL_MSK)	\
+			<< ((channel) * LTC2358_BYTES_PER_CH))
+
+struct ltc2358_state {
+	struct spi_device	*spi;
+};
+
+static int ltc2358_read(struct ltc2358_state *adc, u32 config_word,
+			u8 data_array[24], u8 channel, int *val)
+{
+	int ret;
+	u8 tx_buff[24] = {0};
+
+	struct spi_transfer xfer = {
+		.tx_buf = tx_buff,
+		.rx_buf = data_array,
+		.len = 24,
+		.cs_change = 1,
+		.delay = {
+			.unit = SPI_DELAY_UNIT_NSECS,
+			.value = T_QUIET
+		},
+		.cs_change_delay = {
+			.unit = SPI_DELAY_UNIT_NSECS,
+			.value = T_CONVH
+		}
+	};
+
+	put_unaligned_be24(config_word, tx_buff);
+
+	ret = spi_sync_transfer(adc->spi, &xfer, 1);
+	if (ret)
+		return ret;
+
+	*val = get_unaligned_be24(&data_array[channel * LTC2358_BYTES_PER_CH]);
+
+	return 0;
+}
+
+static int ltc2358_read_raw(struct iio_dev *indio_dev,
+			    struct iio_chan_spec const *chan, int *val,
+			    int *val2, long info)
+{
+	struct ltc2358_state *adc = iio_priv(indio_dev);
+	u8 data_array[24];
+	u32 config_word = 0;
+	int ret;
+
+	switch (info) {
+	case IIO_CHAN_INFO_RAW:
+		ret = ltc2358_read(adc, config_word, data_array, chan->channel, val);
+		if (ret)
+			return ret;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return IIO_VAL_INT;
+}
+
+#define LTC2358_CHAN(name)						\
+	struct iio_chan_spec name = {					\
+		.type = IIO_VOLTAGE,					\
+		.indexed = 1,						\
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),		\
+	}
+
+static const struct iio_info ltc2358_info = {
+	.read_raw = ltc2358_read_raw,
+};
+
+static int ltc2358_parse_channels(struct ltc2358_state *adc,
+				  struct iio_dev *indio_dev)
+{
+	struct iio_chan_spec *ltc2358_channels;
+	struct device *dev = &adc->spi->dev;
+	struct fwnode_handle *child;
+	unsigned int num_ch, idx;
+	int chan_idx = 0;
+	u32 config_word = 0;
+	int config_number, ret;
+
+	num_ch = device_get_child_node_count(dev);
+	if (!num_ch)
+		return -EINVAL;
+
+	ltc2358_channels = devm_kcalloc(dev, num_ch, sizeof(*ltc2358_channels),
+					GFP_KERNEL);
+
+	device_for_each_child_node(dev, child) {
+		LTC2358_CHAN(chan);
+		ret = device_property_read_u32(dev, "reg", &idx);
+		if (ret < 0 || idx > LTC2358_NUM_CH) {
+			fwnode_handle_put(child);
+			dev_err(dev, "Invalid channel index %d.", idx);
+			return -EINVAL;
+		}
+
+		chan.channel = idx;
+
+		ret = device_property_read_u32(dev, "config-number", &config_number);
+		if (ret < 0 || config_number > LTC2358_NUM_CONFIG) {
+			fwnode_handle_put(child);
+			dev_err(dev, "Invalid config number %d.", config_number);
+			return -EINVAL;
+		}
+
+		LTC2358_CREATE_CONFIG_WORD(idx, config_number, &config_word);
+
+		ltc2358_channels[chan_idx] = chan;
+		chan_idx++;
+	}
+
+	indio_dev->channels = ltc2358_channels;
+	indio_dev->num_channels = num_ch;
+
+	return 0;
+}
+
+static int ltc2358_probe(struct spi_device *spi)
+{
+	struct ltc2358_state *adc;
+	struct iio_dev *indio_dev;
+	int ret;
+
+	indio_dev = devm_iio_device_alloc(&spi->dev, sizeof(*adc));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	adc = iio_priv(indio_dev);
+	adc->spi = spi;
+
+	indio_dev->name = "ltc2358";
+	indio_dev->modes = INDIO_DIRECT_MODE;
+	indio_dev->info = &ltc2358_info;
+
+	ret = ltc2358_parse_channels(adc, indio_dev);
+	if (ret)
+		return ret;
+
+	return devm_iio_device_register(&spi->dev, indio_dev);
+}
+
+static const struct of_device_id ltc2358_of_match[] = {
+	{ .compatible = "adi,ltc2358" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, ltc2358_of_match);
+
+static struct spi_device_id ltc2358[] = {
+	{"ltc2358", 0},
+	{ }
+};
+MODULE_DEVICE_TABLE(spi, ltc2358);
+
+static struct spi_driver ltc2358_driver = {
+	.driver = {
+		.name = "ltc2358",
+		.of_match_table = ltc2358_of_match,
+	},
+	.probe = ltc2358_probe,
+	.id_table = ltc2358,
+};
+module_spi_driver(ltc2358_driver);
+
+MODULE_AUTHOR("Kim Seer Paller <kimseer.paller@analog.com>");
+MODULE_DESCRIPTION("Analog Devices LTC2358 ADC");
+MODULE_LICENSE("GPL v2");

--- a/drivers/iio/adc/ltc2358.c
+++ b/drivers/iio/adc/ltc2358.c
@@ -4,6 +4,8 @@
  *
  * Copyright 2023 Analog Devices Inc.
  */
+
+#include <asm/unaligned.h>
 #include <linux/device.h>
 #include <linux/err.h>
 #include <linux/iio/iio.h>
@@ -21,7 +23,7 @@
 #define T_CONVH			40
 #define T_QUIET			20
 #define LTC2358_CREATE_CONFIG_WORD(channel, config_number, config_word)		\
-	*(config_word) |= ((uint32_t)(config_number & LTC2358_CHANNEL_MSK)	\
+	(*config_word) |= ((u32)(config_number & LTC2358_CHANNEL_MSK)		\
 			<< ((channel) * LTC2358_BYTES_PER_CH))
 
 struct ltc2358_state {


### PR DESCRIPTION
Add driver implementation for LTC2358 CMOS Mode.

The LTC2358 is a Buffered Quad, 200ksps/Ch Differential
±10.24V ADC with 30VP-P Common Mode Range.

Signed-off-by: Kim Seer Paller <kimseer.paller@analog.com>