### PR TITLE
dt-bindings: iio: frequency: add admfm2000

### DIFF
--- a/Documentation/devicetree/bindings/iio/frequency/adi,admfm2000.yaml
+++ b/Documentation/devicetree/bindings/iio/frequency/adi,admfm2000.yaml
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+# Copyright 2023 Analog Devices Inc.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/frequency/adi,admfm2000.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: ADMFM2000 Dual Microwave Down Converter
+
+maintainers:
+  - Kim Seer Paller <kimseer.paller@analog.com>
+
+description: |
+    Dual microwave down converter module with input RF and LO frequency ranges
+    from 0.5 to 32 GHz and an output IF frequency range from 0.1 to 8 GHz.
+    It consists of a LNA, mixer, IF filter, DSA, and IF amplifier for each down
+    conversion path.
+
+properties:
+  compatible:
+    enum:
+      - adi,admfm2000
+
+  vcc-supply: true
+
+  switch1-gpios:
+    description:
+      Must contain an array of 2 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 1 switch controls.
+    minItems: 2
+    maxItems: 2
+
+  switch2-gpios:
+    description:
+      Must contain an array of 2 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 2 switch controls.
+    minItems: 2
+    maxItems: 2
+
+  attenuation1-gpios:
+    description:
+      Must contain an array of 5 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 1 DSA attenuation controls.
+    minItems: 5
+    maxItems: 5
+
+  attenuation2-gpios:
+    description:
+      Must contain an array of 5 GPIO specifiers, referring to the GPIO pins
+      connected to the channel 2 DSA attenuation controls.
+    minItems: 5
+    maxItems: 5
+
+  '#address-cells':
+    const: 1
+
+  '#size-cells':
+    const: 0
+
+patternProperties:
+  "^channel@[0-1]$":
+    type: object
+    description: Represents a channel of the device.
+
+    properties:
+      reg:
+        description:
+          The channel number.
+        minimum: 0
+        maximum: 1
+
+      adi,direct-if-mode:
+        description:
+          Bypass mixer mode.
+        type: boolean
+
+    required:
+      - reg
+
+required:
+  - compatible
+  - switch1-gpios
+  - switch2-gpios
+  - attenuation1-gpios
+  - attenuation2-gpios
+
+additionalProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+    admfm2000 {
+      compatible = "adi,admfm2000";
+
+      switch1-gpios = <&gpio 1 GPIO_ACTIVE_LOW>,
+        <&gpio 2 GPIO_ACTIVE_HIGH>;
+
+      switch2-gpios = <&gpio 3 GPIO_ACTIVE_LOW>,
+        <&gpio 4 GPIO_ACTIVE_HIGH>;
+
+      attenuation1-gpios = <&gpio 17 GPIO_ACTIVE_LOW>,
+        <&gpio 22 GPIO_ACTIVE_LOW>,
+        <&gpio 23 GPIO_ACTIVE_LOW>,
+        <&gpio 24 GPIO_ACTIVE_LOW>,
+        <&gpio 25 GPIO_ACTIVE_LOW>;
+
+      attenuation2-gpios = <&gpio 0 GPIO_ACTIVE_LOW>,
+        <&gpio 5 GPIO_ACTIVE_LOW>,
+        <&gpio 6 GPIO_ACTIVE_LOW>,
+        <&gpio 16 GPIO_ACTIVE_LOW>,
+        <&gpio 26 GPIO_ACTIVE_LOW>;
+
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      channel@0 {
+        reg = <0>;
+        adi,direct-if-mode;
+      };
+
+      channel@1 {
+        reg = <1>;
+      };
+    };
+...


### PR DESCRIPTION
Dual microwave down converter module with input RF and LO frequency ranges from 0.5 to 32 GHz and an output IF frequency range from 0.1 to 8 GHz. It consists of a LNA, mixer, IF filter, DSA, and IF amplifier for each down conversion path.